### PR TITLE
pass args via config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ Flags:
   -ami string
         [OPTIONAL] ami id
   -bucket string
-        [OPTIONAL] the name of the bucket created in the last run. When provided with this flag, the CLI won't create new resources, but try to grab test results from the bucket. If you provide this flag, you don't need to specify any required flags
+        [OPTIONAL] the name of the Bucket created in the last run. When provided with this flag, the CLI won't create new resources, but try to grab test results from the Bucket. If you provide this flag, you don't need to specify any required flags
+  -config-file string
+        [OPTIONAL] path to config file for cli input parameters in JSON
   -custom-script string
         [OPTIONAL] path to Bash script to be executed on instance-types BEFORE agent runs test-suite and monitoring
   -instance-types string
@@ -109,7 +111,7 @@ Flags:
   -persist
         [OPTIONAL] set to true if you'd like the tool to keep the CloudFormation stack after the run. Default is deleting the stack
   -profile string
-        [OPTIONAL] AWS CLI profile to use for credentials and config
+        [OPTIONAL] AWS CLI Profile to use for credentials and config
   -region string
         [OPTIONAL] AWS Region to use for API requests
   -subnet string

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,15 +14,13 @@
 package config
 
 import (
-	"bufio"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strconv"
-	"strings"
 
 	homedir "github.com/mitchellh/go-homedir"
 	"gopkg.in/ini.v1"
@@ -52,17 +50,17 @@ func PopulateTestFixture(userConfig UserConfig, runId string, amiId ...string) (
 	testFixture.userConfigFilename = userConfigFilePrefix + testFixture.runId + ".config"
 	testFixture.cfnTemplateFilename = cfnTemplateFilePrefix + testFixture.runId + ".json"
 
-	if userConfig.bucket == "" { // new run
+	if userConfig.Bucket == "" { // new run
 		testFixture.amiId = amiId[0]
-		testFixture.testSuiteName, err = filepath.Abs(userConfig.testSuiteName)
+		testFixture.testSuiteName, err = filepath.Abs(userConfig.TestSuiteName)
 		if err != nil {
 			return err
 		}
 		testFixture.compressedTestSuiteName = testFixture.testSuiteName + compressSuffix
-		testFixture.targetUtil = userConfig.targetUtil
-		testFixture.timeout = userConfig.timeout
+		testFixture.targetUtil = userConfig.TargetUtil
+		testFixture.timeout = userConfig.Timeout
 	} else { // resumed run
-		testFixture.bucketName = userConfig.bucket
+		testFixture.bucketName = userConfig.Bucket
 	}
 
 	return nil
@@ -91,9 +89,9 @@ func ParseCliArgs(outputStream *os.File) (UserConfig, error) {
 Provided with a test suite and a list of EC2 instance types, %s will then
 run the input on all designated types, test against multiple metrics, and output the results
 in a user friendly format`, binName, binName)
-		examples := fmt.Sprintf(`./%s --instance-types=m4.large,c5.large,m4.xlarge --test-suite=path/to/test-folder --target-utilization=30 --vpc=vpc-294b9542 --subnet=subnet-4879bf23 --timeout=2400
-./%s --instance-types=m4.xlarge,c1.large,c5.large --test-suite=path/to/test-folder --target-utilization=50 --profile=default
-./%s --bucket=qualifier-bucket-123456789abcdef`, binName, binName, binName)
+		examples := fmt.Sprintf(`./%s --instance-types=m4.large,c5.large,m4.xlarge --test-suite=path/to/test-folder --target-utilization=30 --vpc=vpc-294b9542 --subnet=subnet-4879bf23 --Timeout=2400
+./%s --instance-types=m4.xlarge,c1.large,c5.large --test-suite=path/to/test-folder --target-utilization=50 --Profile=default
+./%s --Bucket=qualifier-Bucket-123456789abcdef`, binName, binName, binName)
 		fmt.Fprintf(outputStream,
 			longUsage+"\n\n"+
 				"Usage:\n"+
@@ -104,133 +102,86 @@ in a user friendly format`, binName, binName)
 		flag.PrintDefaults()
 	}
 
-	flag.StringVar(&userConfig.instanceTypes, "instance-types", "", "[REQUIRED] comma-separated list of instance-types to test")
-	flag.StringVar(&userConfig.testSuiteName, "test-suite", "", "[REQUIRED] folder containing test files to execute")
-	flag.IntVar(&userConfig.targetUtil, "target-utilization", 0, "[REQUIRED] % of total resource used (CPU, Mem) benchmark (must be an integer). ex: 30 means instances using less than 30% CPU and Mem SUCCEED")
-	flag.StringVar(&userConfig.customScriptPath, "custom-script", "", "[OPTIONAL] path to Bash script to be executed on instance-types BEFORE agent runs test-suite and monitoring")
-	flag.StringVar(&userConfig.vpcId, "vpc", "", "[OPTIONAL] vpc id")
-	flag.StringVar(&userConfig.subnetId, "subnet", "", "[OPTIONAL] subnet id")
-	flag.StringVar(&userConfig.amiId, "ami", "", "[OPTIONAL] ami id")
-	flag.IntVar(&userConfig.timeout, "timeout", defaultTimeout, "[OPTIONAL] max seconds for test-suite execution on instances") // default value will be automatically appended
-	flag.BoolVar(&userConfig.persist, "persist", false, "[OPTIONAL] set to true if you'd like the tool to keep the CloudFormation stack after the run. Default is deleting the stack")
-	flag.StringVar(&userConfig.profile, "profile", "", "[OPTIONAL] AWS CLI profile to use for credentials and config")
-	flag.StringVar(&userConfig.region, "region", "", "[OPTIONAL] AWS Region to use for API requests")
-	flag.StringVar(&userConfig.bucket, "bucket", "", "[OPTIONAL] the name of the bucket created in the last run. When provided with this flag, the CLI won't create new resources, but try to grab test results from the bucket. If you provide this flag, you don't need to specify any required flags")
+	flag.StringVar(&userConfig.InstanceTypes, "instance-types", "", "[REQUIRED] comma-separated list of instance-types to test")
+	flag.StringVar(&userConfig.TestSuiteName, "test-suite", "", "[REQUIRED] folder containing test files to execute")
+	flag.IntVar(&userConfig.TargetUtil, "target-utilization", 0, "[REQUIRED] % of total resource used (CPU, Mem) benchmark (must be an integer). ex: 30 means instances using less than 30% CPU and Mem SUCCEED")
+	flag.StringVar(&userConfig.ConfigFilePath, "config-file", "", "[OPTIONAL] path to config file for cli input parameters in JSON")
+	flag.StringVar(&userConfig.CustomScriptPath, "custom-script", "", "[OPTIONAL] path to Bash script to be executed on instance-types BEFORE agent runs test-suite and monitoring")
+	flag.StringVar(&userConfig.VpcId, "vpc", "", "[OPTIONAL] vpc id")
+	flag.StringVar(&userConfig.SubnetId, "subnet", "", "[OPTIONAL] subnet id")
+	flag.StringVar(&userConfig.AmiId, "ami", "", "[OPTIONAL] ami id")
+	flag.IntVar(&userConfig.Timeout, "timeout", defaultTimeout, "[OPTIONAL] max seconds for test-suite execution on instances") // default value will be automatically appended
+	flag.BoolVar(&userConfig.Persist, "persist", false, "[OPTIONAL] set to true if you'd like the tool to keep the CloudFormation stack after the run. Default is deleting the stack")
+	flag.StringVar(&userConfig.Profile, "profile", "", "[OPTIONAL] AWS CLI Profile to use for credentials and config")
+	flag.StringVar(&userConfig.Region, "region", "", "[OPTIONAL] AWS Region to use for API requests")
+	flag.StringVar(&userConfig.Bucket, "bucket", "", "[OPTIONAL] the name of the Bucket created in the last run. When provided with this flag, the CLI won't create new resources, but try to grab test results from the Bucket. If you provide this flag, you don't need to specify any required flags")
 
 	flag.Parse()
 
+	var configFile string
+	if userConfig.ConfigFilePath != "" {
+		configFile = userConfig.ConfigFilePath
+		fmt.Println("detected config file")
+		_, err := ReadUserConfig(userConfig.ConfigFilePath)
+		if err != nil {
+			return userConfig, err
+		}
+	}
+	// preserve this data if config file defines "config-file" as nil
+	if configFile != "" {
+		userConfig.ConfigFilePath = configFile
+	}
+
 	// Validation
-	if userConfig.bucket == "" {
-		if userConfig.instanceTypes == "" {
+	if userConfig.Bucket == "" {
+		if userConfig.InstanceTypes == "" {
 			return userConfig, errors.New("you must provide a comma-separated list of instance-types")
 		}
-		if userConfig.targetUtil <= 0 {
+		if userConfig.TargetUtil <= 0 {
 			return userConfig, errors.New("you must provide a target-utilization greater than 0")
 		}
-		if userConfig.testSuiteName == "" {
+		if userConfig.TestSuiteName == "" {
 			return userConfig, errors.New("you must provide a folder containing test files to execute")
 		}
 	}
-	if userConfig.timeout <= 0 {
-		return userConfig, errors.New("you must provide a timeout greater than 0")
+	if userConfig.Timeout <= 0 {
+		return userConfig, errors.New("you must provide a Timeout greater than 0")
 	}
 	setUserConfigRegion()
-
-	fmt.Fprintf(outputStream, "Configuration used: %v\n", userConfig)
-
+	fmt.Fprintf(outputStream, "UserConfig after ALL: %v\n", userConfig)
 	return userConfig, nil
 }
 
 // WriteUserConfig writes user config to config file.
-func WriteUserConfig(userConfig UserConfig, filename string) error {
-	file, err := os.Create(filename)
+func WriteUserConfig(filename string) error {
+	configJson, err := json.MarshalIndent(userConfig, "", "\t")
 	if err != nil {
 		return err
 	}
-	defer file.Close()
-
-	configString := fmt.Sprintf(`instance-types: %s
-test-suite: %s
-target-utilization: %d
-vpc: %s
-subnet: %s
-ami: %s
-timeout: %d
-persist: %v
-profile: %s
-region: %s
-bucket: %s`, userConfig.instanceTypes, userConfig.testSuiteName, userConfig.targetUtil, userConfig.vpcId, userConfig.subnetId,
-		userConfig.amiId, userConfig.timeout, userConfig.persist, userConfig.profile, userConfig.region, userConfig.bucket)
-	_, err = file.WriteString(configString)
+	err = ioutil.WriteFile(filename, configJson, 0644)
 	if err != nil {
 		return err
 	}
-	file.Sync()
-
 	return nil
 }
 
 // ReadUserConfig reads user config from config file.
-func ReadUserConfig(filename string) (userConfig UserConfig, err error) {
+func ReadUserConfig(filename string) (UserConfig, error) {
 	configByteData, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return userConfig, err
 	}
-
-	scanner := bufio.NewScanner(strings.NewReader(string(configByteData)))
-	for scanner.Scan() {
-		attr := strings.Split(scanner.Text(), ": ")
-		if len(attr) != 2 { // Check whether the line is a key-value pair
-			return userConfig, fmt.Errorf("invalid user config: %s", scanner.Text())
-		}
-		if err := populateUserConfig(&userConfig, attr[0], attr[1]); err != nil {
-			return userConfig, err
-		}
-	}
-	if err := scanner.Err(); err != nil {
+	err = json.Unmarshal(configByteData, &userConfig)
+	if err != nil {
+		fmt.Println("error while processing config file: ", err)
 		return userConfig, err
 	}
-
 	return userConfig, nil
-}
-
-// populateUserConfig populates one field of the UserConfig struct from a key-value pair.
-func populateUserConfig(userConfig *UserConfig, key string, value string) (err error) {
-	switch key {
-	case "instance-types":
-		userConfig.instanceTypes = value
-	case "test-suite":
-		userConfig.testSuiteName = value
-	case "target-utilization":
-		userConfig.targetUtil, err = strconv.Atoi(value)
-	case "custom-script":
-		userConfig.customScriptPath = value
-	case "vpc":
-		userConfig.vpcId = value
-	case "subnet":
-		userConfig.subnetId = value
-	case "ami":
-		userConfig.amiId = value
-	case "timeout":
-		userConfig.timeout, err = strconv.Atoi(value)
-	case "persist":
-		userConfig.persist, err = strconv.ParseBool(value)
-	case "profile":
-		userConfig.profile = value
-	case "region":
-		userConfig.region = value
-	case "bucket":
-		userConfig.bucket = value
-	default:
-		err = fmt.Errorf("unknown user config")
-	}
-
-	return err
 }
 
 func getProfileRegion(profileName string) (string, error) {
 	if profileName != defaultProfile {
-		profileName = fmt.Sprintf("profile %s", profileName)
+		profileName = fmt.Sprintf("Profile %s", profileName)
 	}
 	awsConfigPath, err := homedir.Expand(awsConfigFile)
 	if err != nil {
@@ -238,39 +189,39 @@ func getProfileRegion(profileName string) (string, error) {
 	}
 	awsConfigIni, err := ini.Load(awsConfigPath)
 	if err != nil {
-		return "", fmt.Errorf("Warning: unable to load aws config file for profile at path: %s", awsConfigPath)
+		return "", fmt.Errorf("Warning: unable to load aws config file for Profile at path: %s", awsConfigPath)
 	}
 	section, err := awsConfigIni.GetSection(profileName)
 	if err != nil {
-		return "", fmt.Errorf("Warning: there is no configuration for the specified aws profile %s at %s", profileName, awsConfigPath)
+		return "", fmt.Errorf("Warning: there is no configuration for the specified aws Profile %s at %s", profileName, awsConfigPath)
 	}
-	regionConfig, err := section.GetKey("region")
+	regionConfig, err := section.GetKey("Region")
 	if err != nil || regionConfig.String() == "" {
-		return "", fmt.Errorf("Warning: there is no region configured for the specified aws profile %s at %s", profileName, awsConfigPath)
+		return "", fmt.Errorf("Warning: there is no Region configured for the specified aws Profile %s at %s", profileName, awsConfigPath)
 	}
 	return regionConfig.String(), nil
 }
 
 func setUserConfigRegion() {
-	if userConfig.region == "" {
-		if userConfig.profile != "" {
-			if profileRegion, err := getProfileRegion(userConfig.profile); err == nil {
-				userConfig.region = profileRegion
+	if userConfig.Region == "" {
+		if userConfig.Profile != "" {
+			if profileRegion, err := getProfileRegion(userConfig.Profile); err == nil {
+				userConfig.Region = profileRegion
 			}
 		} else if envRegion, ok := os.LookupEnv(awsRegionEnvVar); ok && envRegion != "" {
-			userConfig.region = envRegion
+			userConfig.Region = envRegion
 		} else if defaultProfileRegion, err := getProfileRegion(defaultProfile); err == nil {
-			userConfig.region = defaultProfileRegion
+			userConfig.Region = defaultProfileRegion
 		} else if defaultRegion, ok := os.LookupEnv(defaultRegionEnvVar); ok && defaultRegion != "" {
-			userConfig.region = defaultRegion
+			userConfig.Region = defaultRegion
 		} else {
-			errorMsg := "Failed to determine region from the following sources: \n"
-			errorMsg = errorMsg + "\t - --region flag\n"
-			if userConfig.profile != "" {
-				errorMsg = errorMsg + fmt.Sprintf("\t - profile region in %s\n", awsConfigFile)
+			errorMsg := "Failed to determine Region from the following sources: \n"
+			errorMsg = errorMsg + "\t - --Region flag\n"
+			if userConfig.Profile != "" {
+				errorMsg = errorMsg + fmt.Sprintf("\t - Profile Region in %s\n", awsConfigFile)
 			}
 			errorMsg = errorMsg + fmt.Sprintf("\t - %s environment variable\n", awsRegionEnvVar)
-			errorMsg = errorMsg + fmt.Sprintf("\t - default profile region in %s\n", awsConfigFile)
+			errorMsg = errorMsg + fmt.Sprintf("\t - default Profile Region in %s\n", awsConfigFile)
 			errorMsg = errorMsg + fmt.Sprintf("\t - %s environment variable\n", defaultRegionEnvVar)
 			fmt.Println(errorMsg)
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -117,16 +117,18 @@ in a user friendly format`, binName, binName)
 	flag.StringVar(&userConfig.Bucket, "bucket", "", "[OPTIONAL] the name of the Bucket created in the last run. When provided with this flag, the CLI won't create new resources, but try to grab test results from the Bucket. If you provide this flag, you don't need to specify any required flags")
 
 	flag.Parse()
+	setUserConfigRegion()
 
 	var configFile string
 	if userConfig.ConfigFilePath != "" {
 		configFile = userConfig.ConfigFilePath
-		fmt.Println("detected config file")
-		_, err := ReadUserConfig(userConfig.ConfigFilePath)
+		tmpConfig, err := ReadUserConfig(userConfig.ConfigFilePath)
+		userConfig.SetUserConfig(tmpConfig)
 		if err != nil {
 			return userConfig, err
 		}
 	}
+
 	// preserve this data if config file defines "config-file" as nil
 	if configFile != "" {
 		userConfig.ConfigFilePath = configFile
@@ -147,7 +149,6 @@ in a user friendly format`, binName, binName)
 	if userConfig.Timeout <= 0 {
 		return userConfig, errors.New("you must provide a timeout greater than 0")
 	}
-	setUserConfigRegion()
 	fmt.Fprintf(outputStream, "UserConfig: %v\n", userConfig)
 	return userConfig, nil
 }
@@ -167,16 +168,17 @@ func WriteUserConfig(filename string) error {
 
 // ReadUserConfig reads user config from config file.
 func ReadUserConfig(filename string) (UserConfig, error) {
+	result := UserConfig{}
 	configByteData, err := ioutil.ReadFile(filename)
 	if err != nil {
-		return userConfig, err
+		return result, err
 	}
-	err = json.Unmarshal(configByteData, &userConfig)
+	err = json.Unmarshal(configByteData, &result)
 	if err != nil {
 		fmt.Println("error while processing config file: ", err)
-		return userConfig, err
+		return result, err
 	}
-	return userConfig, nil
+	return result, nil
 }
 
 func getProfileRegion(profileName string) (string, error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -89,9 +89,9 @@ func ParseCliArgs(outputStream *os.File) (UserConfig, error) {
 Provided with a test suite and a list of EC2 instance types, %s will then
 run the input on all designated types, test against multiple metrics, and output the results
 in a user friendly format`, binName, binName)
-		examples := fmt.Sprintf(`./%s --instance-types=m4.large,c5.large,m4.xlarge --test-suite=path/to/test-folder --target-utilization=30 --vpc=vpc-294b9542 --subnet=subnet-4879bf23 --Timeout=2400
-./%s --instance-types=m4.xlarge,c1.large,c5.large --test-suite=path/to/test-folder --target-utilization=50 --Profile=default
-./%s --Bucket=qualifier-Bucket-123456789abcdef`, binName, binName, binName)
+		examples := fmt.Sprintf(`./%s --instance-types=m4.large,c5.large,m4.xlarge --test-suite=path/to/test-folder --target-utilization=30 --vpc=vpc-294b9542 --subnet=subnet-4879bf23 --timeout=2400
+./%s --instance-types=m4.xlarge,c1.large,c5.large --test-suite=path/to/test-folder --target-utilization=50 --profile=default
+./%s --bucket=qualifier-Bucket-123456789abcdef`, binName, binName, binName)
 		fmt.Fprintf(outputStream,
 			longUsage+"\n\n"+
 				"Usage:\n"+
@@ -145,10 +145,10 @@ in a user friendly format`, binName, binName)
 		}
 	}
 	if userConfig.Timeout <= 0 {
-		return userConfig, errors.New("you must provide a Timeout greater than 0")
+		return userConfig, errors.New("you must provide a timeout greater than 0")
 	}
 	setUserConfigRegion()
-	fmt.Fprintf(outputStream, "UserConfig after ALL: %v\n", userConfig)
+	fmt.Fprintf(outputStream, "UserConfig: %v\n", userConfig)
 	return userConfig, nil
 }
 
@@ -181,7 +181,7 @@ func ReadUserConfig(filename string) (UserConfig, error) {
 
 func getProfileRegion(profileName string) (string, error) {
 	if profileName != defaultProfile {
-		profileName = fmt.Sprintf("Profile %s", profileName)
+		profileName = fmt.Sprintf("profile %s", profileName)
 	}
 	awsConfigPath, err := homedir.Expand(awsConfigFile)
 	if err != nil {
@@ -193,11 +193,11 @@ func getProfileRegion(profileName string) (string, error) {
 	}
 	section, err := awsConfigIni.GetSection(profileName)
 	if err != nil {
-		return "", fmt.Errorf("Warning: there is no configuration for the specified aws Profile %s at %s", profileName, awsConfigPath)
+		return "", fmt.Errorf("Warning: there is no configuration for the specified aws profile %s at %s", profileName, awsConfigPath)
 	}
 	regionConfig, err := section.GetKey("Region")
 	if err != nil || regionConfig.String() == "" {
-		return "", fmt.Errorf("Warning: there is no Region configured for the specified aws Profile %s at %s", profileName, awsConfigPath)
+		return "", fmt.Errorf("Warning: there is no region configured for the specified aws profile %s at %s", profileName, awsConfigPath)
 	}
 	return regionConfig.String(), nil
 }
@@ -215,13 +215,13 @@ func setUserConfigRegion() {
 		} else if defaultRegion, ok := os.LookupEnv(defaultRegionEnvVar); ok && defaultRegion != "" {
 			userConfig.Region = defaultRegion
 		} else {
-			errorMsg := "Failed to determine Region from the following sources: \n"
-			errorMsg = errorMsg + "\t - --Region flag\n"
+			errorMsg := "Failed to determine region from the following sources: \n"
+			errorMsg = errorMsg + "\t - --region flag\n"
 			if userConfig.Profile != "" {
-				errorMsg = errorMsg + fmt.Sprintf("\t - Profile Region in %s\n", awsConfigFile)
+				errorMsg = errorMsg + fmt.Sprintf("\t - profile region in %s\n", awsConfigFile)
 			}
 			errorMsg = errorMsg + fmt.Sprintf("\t - %s environment variable\n", awsRegionEnvVar)
-			errorMsg = errorMsg + fmt.Sprintf("\t - default Profile Region in %s\n", awsConfigFile)
+			errorMsg = errorMsg + fmt.Sprintf("\t - default profile region in %s\n", awsConfigFile)
 			errorMsg = errorMsg + fmt.Sprintf("\t - %s environment variable\n", defaultRegionEnvVar)
 			fmt.Println(errorMsg)
 		}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -56,12 +56,12 @@ func TestPopulateTestFixtureForNewRun(t *testing.T) {
 	resetTestFixture()
 	// For new run, bucketName should already be set before calling PopulateTestFixture
 	testFixture.bucketName = "BUCKET_NAME"
-	userConfig := UserConfig{
-		instanceTypes: "INSTANCE_TYPES",
-		testSuiteName: "TEST_SUITE_NAME",
-		targetUtil:    50,
-		timeout:       12345,
-		region:        "REGION",
+	userConfig = UserConfig{
+		InstanceTypes: "INSTANCE_TYPES",
+		TestSuiteName: "TEST_SUITE_NAME",
+		TargetUtil:    50,
+		Timeout:       12345,
+		Region:        "REGION",
 	}
 
 	err := PopulateTestFixture(userConfig, "RUN_ID", "AMI_ID")
@@ -86,9 +86,9 @@ func TestPopulateTestFixtureForNewRun(t *testing.T) {
 
 func TestPopulateTestFixtureForResumedRun(t *testing.T) {
 	resetTestFixture()
-	userConfig := UserConfig{
-		bucket:  "BUCKET_NAME",
-		timeout: 3600,
+	userConfig = UserConfig{
+		Bucket:  "BUCKET_NAME",
+		Timeout: 3600,
 	}
 
 	err := PopulateTestFixture(userConfig, "RUN_ID")
@@ -121,7 +121,7 @@ func TestParseCliArgsEnvSuccess(t *testing.T) {
 	userConfig, err := ParseCliArgs(outputStream)
 	h.Ok(t, err)
 
-	h.Equals(t, "us-weast-1", userConfig.Region())
+	h.Equals(t, "us-weast-1", userConfig.Region)
 }
 
 func TestParseCliArgsSuccess(t *testing.T) {
@@ -145,18 +145,38 @@ func TestParseCliArgsSuccess(t *testing.T) {
 	h.Ok(t, err)
 
 	// Assert all the values were set
-	h.Equals(t, "INSTANCE_TYPES", userConfig.InstanceTypes())
-	h.Equals(t, "TEST_SUITE", userConfig.TestSuiteName())
-	h.Equals(t, 30, userConfig.TargetUtil())
-	h.Equals(t, "VPC", userConfig.VpcId())
-	h.Equals(t, "SUBNET", userConfig.SubnetId())
-	h.Equals(t, "AMI", userConfig.AmiId())
-	h.Equals(t, 12345, userConfig.Timeout())
-	h.Equals(t, true, userConfig.Persist())
-	h.Equals(t, "PROFILE", userConfig.Profile())
-	h.Equals(t, "REGION", userConfig.Region())
-	h.Equals(t, "BUCKET", userConfig.Bucket())
-	h.Equals(t, "/path/to/script", userConfig.CustomScriptPath())
+	h.Equals(t, "INSTANCE_TYPES", userConfig.InstanceTypes)
+	h.Equals(t, "TEST_SUITE", userConfig.TestSuiteName)
+	h.Equals(t, 30, userConfig.TargetUtil)
+	h.Equals(t, "VPC", userConfig.VpcId)
+	h.Equals(t, "SUBNET", userConfig.SubnetId)
+	h.Equals(t, "AMI", userConfig.AmiId)
+	h.Equals(t, 12345, userConfig.Timeout)
+	h.Equals(t, true, userConfig.Persist)
+	h.Equals(t, "PROFILE", userConfig.Profile)
+	h.Equals(t, "REGION", userConfig.Region)
+	h.Equals(t, "BUCKET", userConfig.Bucket)
+	h.Equals(t, "/path/to/script", userConfig.CustomScriptPath)
+}
+
+func TestParseCliArgsPriority(t *testing.T) {
+	resetFlagsForTest()
+	os.Setenv("AWS_REGION", "us-weast-1")
+	os.Args = []string{
+		"cmd",
+		"--instance-types=INSTANCE_TYPES",
+		"--test-suite=TEST_SUITE",
+		"--target-utilization=30",
+		"--config-file=../../test/static/UserConfigFiles/valid.config",
+	}
+	userConfig, err := ParseCliArgs(outputStream)
+	h.Ok(t, err)
+
+	h.Equals(t, "INSTANCE_TYPES", userConfig.InstanceTypes)
+	h.Equals(t, "us-east-2", userConfig.Region)
+	h.Equals(t, 50, userConfig.TargetUtil)
+	h.Equals(t, 12345, userConfig.Timeout)
+	h.Equals(t, "../../test/static/UserConfigFiles/valid.config", userConfig.ConfigFilePath)
 }
 
 func TestParseCliArgsOnlyBucketSuccess(t *testing.T) {
@@ -168,7 +188,7 @@ func TestParseCliArgsOnlyBucketSuccess(t *testing.T) {
 	userConfig, err := ParseCliArgs(outputStream)
 	h.Ok(t, err)
 
-	h.Equals(t, "BUCKET", userConfig.Bucket())
+	h.Equals(t, "BUCKET", userConfig.Bucket)
 }
 
 func TestParseCliArgsOverrides(t *testing.T) {
@@ -191,16 +211,16 @@ func TestParseCliArgsOverrides(t *testing.T) {
 	h.Ok(t, err)
 
 	// Assert all the values were set
-	h.Equals(t, "INSTANCE_TYPES", userConfig.InstanceTypes())
-	h.Equals(t, "TEST_SUITE", userConfig.TestSuiteName())
-	h.Equals(t, 30, userConfig.TargetUtil())
-	h.Equals(t, "VPC", userConfig.VpcId())
-	h.Equals(t, "SUBNET", userConfig.SubnetId())
-	h.Equals(t, "AMI", userConfig.AmiId())
-	h.Equals(t, 12345, userConfig.Timeout())
-	h.Equals(t, true, userConfig.Persist())
-	h.Equals(t, "PROFILE", userConfig.Profile())
-	h.Equals(t, "REGION", userConfig.Region())
+	h.Equals(t, "INSTANCE_TYPES", userConfig.InstanceTypes)
+	h.Equals(t, "TEST_SUITE", userConfig.TestSuiteName)
+	h.Equals(t, 30, userConfig.TargetUtil)
+	h.Equals(t, "VPC", userConfig.VpcId)
+	h.Equals(t, "SUBNET", userConfig.SubnetId)
+	h.Equals(t, "AMI", userConfig.AmiId)
+	h.Equals(t, 12345, userConfig.Timeout)
+	h.Equals(t, true, userConfig.Persist)
+	h.Equals(t, "PROFILE", userConfig.Profile)
+	h.Equals(t, "REGION", userConfig.Region)
 }
 
 func TestParseCliArgsMissingInstanceTypesFailure(t *testing.T) {
@@ -273,22 +293,22 @@ func TestParseCliArgsNonPositiveTimeoutFailure(t *testing.T) {
 		"--timeout=0",
 	}
 	_, err := ParseCliArgs(outputStream)
-	h.Assert(t, err != nil, "Failed to return error when non-positive timeout provided")
+	h.Assert(t, err != nil, "Failed to return error when non-positive Timeout provided")
 }
 
 func TestWriteUserConfigSuccess(t *testing.T) {
 	actualConfigFile := "actual.config"
 	defer os.Remove(actualConfigFile)
-	userConfig := UserConfig{
-		instanceTypes: "INSTANCE_TYPES",
-		testSuiteName: "TEST_SUITE",
-		targetUtil:    50,
-		vpcId:         "VPC_ID",
-		timeout:       12345,
-		region:        "us-east-2",
+	userConfig = UserConfig{
+		InstanceTypes: "INSTANCE_TYPES",
+		TestSuiteName: "TEST_SUITE",
+		TargetUtil:    50,
+		VpcId:         "VPC_ID",
+		Timeout:       12345,
+		Region:        "us-east-2",
 	}
 
-	err := WriteUserConfig(userConfig, actualConfigFile)
+	err := WriteUserConfig(actualConfigFile)
 	h.Ok(t, err)
 
 	// Assert files contents are same
@@ -300,42 +320,42 @@ func TestWriteUserConfigSuccess(t *testing.T) {
 }
 
 func TestWriteUserConfigNonExistentFilePathFailure(t *testing.T) {
-	userConfig := UserConfig{
-		instanceTypes: "INSTANCE_TYPES",
-		testSuiteName: "TEST_SUITE",
-		targetUtil:    50,
-		timeout:       12345,
+	userConfig = UserConfig{
+		InstanceTypes: "INSTANCE_TYPES",
+		TestSuiteName: "TEST_SUITE",
+		TargetUtil:    50,
+		Timeout:       12345,
 	}
 
-	err := WriteUserConfig(userConfig, "non-existent-folder/CONFIG.config")
+	err := WriteUserConfig("non-existent-folder/CONFIG.config")
 	h.Assert(t, err != nil, "Failed to return error when file path doesn't exist")
 }
 
 func TestReadUserConfigSuccess(t *testing.T) {
 	expected := UserConfig{
-		instanceTypes: "INSTANCE_TYPES",
-		testSuiteName: "TEST_SUITE",
-		targetUtil:    50,
-		vpcId:         "VPC_ID",
-		timeout:       12345,
-		region:        "us-east-2",
+		InstanceTypes: "INSTANCE_TYPES",
+		TestSuiteName: "TEST_SUITE",
+		TargetUtil:    50,
+		VpcId:         "VPC_ID",
+		Timeout:       12345,
+		Region:        "us-east-2",
 	}
 
 	actual, err := ReadUserConfig(configFilesPath + "/valid.config")
 	h.Ok(t, err)
 
 	// Assert all fields are same
-	h.Equals(t, expected.InstanceTypes(), actual.InstanceTypes())
-	h.Equals(t, expected.TestSuiteName(), actual.TestSuiteName())
-	h.Equals(t, expected.TargetUtil(), actual.TargetUtil())
-	h.Equals(t, expected.VpcId(), actual.VpcId())
-	h.Equals(t, expected.SubnetId(), actual.SubnetId())
-	h.Equals(t, expected.AmiId(), actual.AmiId())
-	h.Equals(t, expected.Timeout(), actual.Timeout())
-	h.Equals(t, expected.Persist(), actual.Persist())
-	h.Equals(t, expected.Profile(), actual.Profile())
-	h.Equals(t, expected.Region(), actual.Region())
-	h.Equals(t, expected.Bucket(), actual.Bucket())
+	h.Equals(t, expected.InstanceTypes, actual.InstanceTypes)
+	h.Equals(t, expected.TestSuiteName, actual.TestSuiteName)
+	h.Equals(t, expected.TargetUtil, actual.TargetUtil)
+	h.Equals(t, expected.VpcId, actual.VpcId)
+	h.Equals(t, expected.SubnetId, actual.SubnetId)
+	h.Equals(t, expected.AmiId, actual.AmiId)
+	h.Equals(t, expected.Timeout, actual.Timeout)
+	h.Equals(t, expected.Persist, actual.Persist)
+	h.Equals(t, expected.Profile, actual.Profile)
+	h.Equals(t, expected.Region, actual.Region)
+	h.Equals(t, expected.Bucket, actual.Bucket)
 }
 
 func TestReadUserConfigNonExistentFileFailure(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -160,11 +160,15 @@ func TestParseCliArgsSuccess(t *testing.T) {
 }
 
 func TestParseCliArgsPriority(t *testing.T) {
+	// Priority:
+	// 1. CLI Args
+	// 2. Env Vars
+	// 3. Config File
 	resetFlagsForTest()
 	os.Setenv("AWS_REGION", "us-weast-1")
 	os.Args = []string{
 		"cmd",
-		"--instance-types=INSTANCE_TYPES",
+		"--instance-types=INSTANCE_TYPES_Args",
 		"--test-suite=TEST_SUITE",
 		"--target-utilization=30",
 		"--config-file=../../test/static/UserConfigFiles/valid.config",
@@ -172,11 +176,11 @@ func TestParseCliArgsPriority(t *testing.T) {
 	userConfig, err := ParseCliArgs(outputStream)
 	h.Ok(t, err)
 
-	h.Equals(t, "INSTANCE_TYPES", userConfig.InstanceTypes)
-	h.Equals(t, "us-east-2", userConfig.Region)
-	h.Equals(t, 50, userConfig.TargetUtil)
-	h.Equals(t, 12345, userConfig.Timeout)
-	h.Equals(t, "../../test/static/UserConfigFiles/valid.config", userConfig.ConfigFilePath)
+	h.Equals(t, "INSTANCE_TYPES_Args", userConfig.InstanceTypes)                             //Args
+	h.Equals(t, 30, userConfig.TargetUtil)                                                   //Args
+	h.Equals(t, "../../test/static/UserConfigFiles/valid.config", userConfig.ConfigFilePath) //Args
+	h.Equals(t, "us-weast-1", userConfig.Region)                                             //Env
+	h.Equals(t, 12345, userConfig.Timeout)                                                   //Config File
 }
 
 func TestParseCliArgsOnlyBucketSuccess(t *testing.T) {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -108,3 +108,46 @@ func (t TestFixture) CfnTemplateFilename() string {
 func (t TestFixture) AmiId() string {
 	return t.amiId
 }
+
+// SetUserConfig sets empty fields of UserConfig to reqConfig
+func (UserConfig) SetUserConfig(reqConfig UserConfig) {
+	if userConfig.InstanceTypes == "" {
+		userConfig.InstanceTypes = reqConfig.InstanceTypes
+	}
+	if userConfig.TestSuiteName == "" {
+		userConfig.TestSuiteName = reqConfig.TestSuiteName
+	}
+	if userConfig.TargetUtil <= 0 {
+		userConfig.TargetUtil = reqConfig.TargetUtil
+	}
+	if userConfig.VpcId == "" {
+		userConfig.VpcId = reqConfig.VpcId
+	}
+	if userConfig.SubnetId == "" {
+		userConfig.SubnetId = reqConfig.SubnetId
+	}
+	if userConfig.AmiId == "" {
+		userConfig.AmiId = reqConfig.AmiId
+	}
+	if userConfig.Timeout == defaultTimeout && reqConfig.Timeout > 0 {
+		userConfig.Timeout = reqConfig.Timeout
+	}
+	if userConfig.Persist != true {
+		userConfig.Persist = reqConfig.Persist
+	}
+	if userConfig.Profile == "" {
+		userConfig.Profile = reqConfig.Profile
+	}
+	if userConfig.Region == "" {
+		userConfig.Region = reqConfig.Region
+	}
+	if userConfig.Bucket == "" {
+		userConfig.Bucket = reqConfig.Bucket
+	}
+	if userConfig.CustomScriptPath == "" {
+		userConfig.CustomScriptPath = reqConfig.CustomScriptPath
+	}
+	if userConfig.ConfigFilePath == "" {
+		userConfig.ConfigFilePath = reqConfig.ConfigFilePath
+	}
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -15,18 +15,19 @@ package config
 
 // UserConfig contains configuration provided by the user, which remains unchanged throughout the entire run.
 type UserConfig struct {
-	instanceTypes    string
-	testSuiteName    string
-	targetUtil       int
-	vpcId            string
-	subnetId         string
-	amiId            string
-	timeout          int
-	persist          bool
-	profile          string
-	region           string
-	bucket           string
-	customScriptPath string
+	InstanceTypes    string `json:"instance-types"`
+	TestSuiteName    string `json:"test-suite"`
+	TargetUtil       int    `json:"target-utilization"`
+	VpcId            string `json:"vpc"`
+	SubnetId         string `json:"subnet"`
+	AmiId            string `json:"ami"`
+	Timeout          int    `json:"timeout"`
+	Persist          bool   `json:"persist"`
+	Profile          string `json:"profile"`
+	Region           string `json:"region"`
+	Bucket           string `json:"bucket"`
+	CustomScriptPath string `json:"custom-script"`
+	ConfigFilePath   string `json:"config-file"`
 }
 
 // TestFixture contains constant information for the entire run.
@@ -48,72 +49,12 @@ type TestFixture struct {
 var testFixture TestFixture
 var userConfig UserConfig
 
-// InstanceTypes returns instanceTypes.
-func (u UserConfig) InstanceTypes() string {
-	return u.instanceTypes
-}
-
-// TestSuiteName returns testSuiteName.
-func (u UserConfig) TestSuiteName() string {
-	return u.testSuiteName
-}
-
-// TargetUtil returns targetUtil.
-func (u UserConfig) TargetUtil() int {
-	return u.targetUtil
-}
-
-// CustomScriptPath returns customScriptPath.
-func (u UserConfig) CustomScriptPath() string {
-	return u.customScriptPath
-}
-
-// VpcId returns vpcId.
-func (u UserConfig) VpcId() string {
-	return u.vpcId
-}
-
-// SubnetId returns subnetId.
-func (u UserConfig) SubnetId() string {
-	return u.subnetId
-}
-
-// AmiId returns amiId.
-func (u UserConfig) AmiId() string {
-	return u.amiId
-}
-
-// Timeout returns timeout.
-func (u UserConfig) Timeout() int {
-	return u.timeout
-}
-
-// Persist returns persist.
-func (u UserConfig) Persist() bool {
-	return u.persist
-}
-
-// Profile returns profile.
-func (u UserConfig) Profile() string {
-	return u.profile
-}
-
-// Region returns region.
-func (u UserConfig) Region() string {
-	return u.region
-}
-
-// Bucket returns bucket.
-func (u UserConfig) Bucket() string {
-	return u.bucket
-}
-
 // RunId returns runId.
 func (t TestFixture) RunId() string {
 	return t.runId
 }
 
-// TestSuiteName returns testSuiteName.
+// TestSuiteName returns TestSuiteName.
 func (t TestFixture) TestSuiteName() string {
 	return t.testSuiteName
 }
@@ -133,12 +74,12 @@ func (t TestFixture) BucketRootDir() string {
 	return t.bucketRootDir
 }
 
-// TargetUtil returns targetUtil.
+// TargetUtil returns TargetUtil.
 func (t TestFixture) TargetUtil() int {
 	return t.targetUtil
 }
 
-// Timeout returns timeout.
+// Timeout returns Timeout.
 func (t TestFixture) Timeout() int {
 	return t.timeout
 }
@@ -163,7 +104,7 @@ func (t TestFixture) CfnTemplateFilename() string {
 	return t.cfnTemplateFilename
 }
 
-// AmiId returns amiId.
+// AmiId returns AmiId.
 func (t TestFixture) AmiId() string {
 	return t.amiId
 }

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -266,7 +266,7 @@ func populateUserData(instance resources.Instance) string {
 		return ""
 	}
 	var customScript []byte
-	customScriptPath := userConfig.CustomScriptPath()
+	customScriptPath := userConfig.CustomScriptPath
 	if customScriptPath != "" {
 		customScript, err = ioutil.ReadFile(customScriptPath)
 		if err != nil {
@@ -292,7 +292,7 @@ func populateUserData(instance resources.Instance) string {
 		CompressedTestSuiteName: compressedTestSuiteName,
 		TestSuiteName:           testSuiteName,
 		CustomScript:            string(customScript),
-		Region:                  userConfig.Region(),
+		Region:                  userConfig.Region,
 	}
 	var byteBuffer bytes.Buffer
 	err = t.Execute(&byteBuffer, userScript)

--- a/test/e2e/cmd/target-utilization-test
+++ b/test/e2e/cmd/target-utilization-test
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+CONFIG_FILE=$SCRIPTPATH/testdata/test-folder_timeout_with_unsupported_instance_types/target-util-80-args.json
+
 function test() {
   cmd=$1
   instance_types=$2
@@ -19,7 +21,7 @@ function test() {
 
 test "$AEIQ_BIN --instance-types=$SUPPORTED_INSTANCE_TYPES --test-suite=${TEST_SUITE}_no_optional_flags --target-utilization=99 --custom-script=$CUSTOM_SCRIPT" "$SUPPORTED_INSTANCE_TYPES" "no_optional_flags" "target_util_99.golden" & pids+=($!)
 sleep 1
-test "$AEIQ_BIN --instance-types=$ALL_INSTANCE_TYPES --test-suite=${TEST_SUITE}_timeout_with_unsupported_instance_types --target-utilization=80 --subnet=$SUBNET_ID --timeout=125 --custom-script=$CUSTOM_SCRIPT" "$ALL_INSTANCE_TYPES" "timeout_with_unsupported_instance_types" "target_util_80_timeout.golden" & pids+=($!)
+test "$AEIQ_BIN --config-file=$CONFIG_FILE --test-suite=${TEST_SUITE}_timeout_with_unsupported_instance_types --subnet=$SUBNET_ID --custom-script=$CUSTOM_SCRIPT" "$ALL_INSTANCE_TYPES" "timeout_with_unsupported_instance_types" "target_util_80_timeout.golden" & pids+=($!)
 sleep 1
 test "$AEIQ_BIN --instance-types=$SUPPORTED_INSTANCE_TYPES --test-suite=${TEST_SUITE}_short_timeout --target-utilization=30 --vpc=$VPC_ID --subnet=$SUBNET_ID --timeout=5 --custom-script=$CUSTOM_SCRIPT" "$SUPPORTED_INSTANCE_TYPES" "short_timeout" "target_util_30_short_timeout.golden" & pids+=($!)
 

--- a/test/e2e/testdata/test-folder_timeout_with_unsupported_instance_types/target-util-80-args.json
+++ b/test/e2e/testdata/test-folder_timeout_with_unsupported_instance_types/target-util-80-args.json
@@ -1,0 +1,5 @@
+{
+  "instance-types": "m4.large,m4.xlarge,c4.large,a1.large,c5a.12xlarge",
+  "target-utilization": 80,
+  "timeout": 125
+}

--- a/test/static/UserConfigFiles/valid.config
+++ b/test/static/UserConfigFiles/valid.config
@@ -1,11 +1,15 @@
-instance-types: INSTANCE_TYPES
-test-suite: TEST_SUITE
-target-utilization: 50
-vpc: VPC_ID
-subnet: 
-ami: 
-timeout: 12345
-persist: false
-profile: 
-region: us-east-2
-bucket: 
+{
+	"instance-types": "INSTANCE_TYPES",
+	"test-suite": "TEST_SUITE",
+	"target-utilization": 50,
+	"vpc": "VPC_ID",
+	"subnet": "",
+	"ami": "",
+	"timeout": 12345,
+	"persist": false,
+	"profile": "",
+	"region": "us-east-2",
+	"bucket": "",
+	"custom-script": "",
+	"config-file": ""
+}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
* args can be passed as JSON via `--config-file` flag
  * config file **will take precedence** over args provided via CLI or as Env Vars
* Updated *userConfig* accessibility from private to public to leverage JSON marshal + unmarshal
* Updated tests and documentation
* Fix bucket creation as e2e tests sometimes stall and fail due to 'bucket already created' error

*Testing:*
* `make clean` && `make test` locally


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
